### PR TITLE
Use environment variables to access Twitter key and secret

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,4 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
-  provider :twitter, Rails.application.secrets.twitter_api_key, Rails.application.secrets.twitter_api_secret
+  # provider :twitter, Rails.application.secrets.twitter_api_key, Rails.application.secrets.twitter_api_secret
+  provider :twitter, ENV['TWITTER_KEY'], ENV['TWITTER_SECRET']
 end


### PR DESCRIPTION
Be sure that your command-line shell's startup script (e.g., .zshrc if you use ZSH or .bashrc if you use Bash) exports your Twitter key and secret. Rails.application.secrets refers to values in the config/secrets.yml file, but you don't want to store API keys in there because they would then be exposed publicly on GitHub.

The lines in your startup script will look something like this (these are obviously fake keys; use your real ones):

```
export TWITTER_KEY=asdflkjsdfoiuww
export TWITTER_SECRET=lkjsdlfkjadfooijasdfoijaAROIUR
```